### PR TITLE
Adapt sn key to ro.factory.psn and screen density key to ro.sf.lcd_density

### DIFF
--- a/src/uv_devinfo.c
+++ b/src/uv_devinfo.c
@@ -34,7 +34,7 @@
 #define CONFIG_DEVICE_MANUFACTURER_KEY "ro.product.manufacturer"
 #define CONFIG_DEVICE_DEVICETYPE_KEY "ro.product.device.devicetype"
 #define CONFIG_DEVICE_SCREENSHAPE_KEY "ro.product.device.screenshape"
-#define CONFIG_DEVICE_SCREENDENSITY_KEY "ro.product.device.screendensity"
+#define CONFIG_DEVICE_SCREENDENSITY_KEY "ro.sf.lcd_density"
 #define CONFIG_DEVICE_LANGUAGE_KEY "ro.system.language"
 #define CONFIG_DEVICE_REGION_KEY "ro.system.region"
 #define CONFIG_DEVICE_OSVERSIONCODE_KEY "ro.system.osversioncode"
@@ -313,8 +313,8 @@ int uv_getdeviceinfo(uv_devinfo_t* info)
 
         info->osversioncode = property_get_int32(CONFIG_DEVICE_OSVERSIONCODE_KEY, CONFIG_VERSION);
 
-        property_get(CONFIG_DEVICE_SCREENDENSITY_KEY, kvbuf, "1.0");
-        info->screendensity = atof(kvbuf);
+        property_get(CONFIG_DEVICE_SCREENDENSITY_KEY, kvbuf, "160.0");
+        info->screendensity = (int)((atof(kvbuf) / 16.0 + 0.5)) / 10.0;
 
         DEVICE_PROPERTY_GET(CONFIG_DEVICE_SCREENSHAPE_KEY, info->screenshape, "unknown");
         DEVICE_PROPERTY_GET(CONFIG_DEVICE_DEVICETYPE_KEY, info->devicetype, "unknown");

--- a/src/uv_devinfo.c
+++ b/src/uv_devinfo.c
@@ -27,7 +27,7 @@
 #include <sys/utsname.h>
 #include <uv_ext.h>
 
-#define CONFIG_FACT_WIFIMAC_KEY "ro.factory.mac_wifi"
+#define CONFIG_FACT_SN_KEY "ro.factory.psn"
 #define CONFIG_DEVICE_BRAND_KEY "ro.product.brand"
 #define CONFIG_DEVICE_MODEL_KEY "ro.product.model"
 #define CONFIG_DEVICE_PRODUCT_KEY "ro.product.name"
@@ -200,7 +200,7 @@ int uv_devinfobuff(char* buff, int size, int item)
 #if defined(CONFIG_KVDB) && defined(CONFIG_CRYPTO_MBEDTLS)
         uv_buf_t input, output, ret;
         char kvbuf[PROP_VALUE_MAX] = { 0 };
-        property_get(CONFIG_FACT_WIFIMAC_KEY, kvbuf, "NA");
+        property_get(CONFIG_FACT_SN_KEY, kvbuf, "NA");
         strlcpy(buff, kvbuf, size);
         input.base = (char*)buff;
         input.len = strlen(buff);
@@ -217,7 +217,7 @@ int uv_devinfobuff(char* buff, int size, int item)
     case UV_EXT_DEVINFO_SERIAL: {
 #if defined(CONFIG_KVDB) && defined(CONFIG_CRYPTO_MBEDTLS)
         char kvbuf[PROP_VALUE_MAX] = { 0 };
-        property_get(CONFIG_FACT_WIFIMAC_KEY, kvbuf, "NA");
+        property_get(CONFIG_FACT_SN_KEY, kvbuf, "NA");
         strlcpy(buff, kvbuf, size);
 #endif
         break;
@@ -333,7 +333,7 @@ int uv_getdeviceinfo(uv_devinfo_t* info)
     {
         uv_buf_t input, output, ret;
         char kvbuf[PROP_VALUE_MAX] = { 0 };
-        property_get(CONFIG_FACT_WIFIMAC_KEY, kvbuf, "NA");
+        property_get(CONFIG_FACT_SN_KEY, kvbuf, "NA");
         strlcpy(info->did, kvbuf, sizeof(info->did));
         input.base = (char*)info->did;
         input.len = strlen(info->did);


### PR DESCRIPTION
## Summary

Adapt sn key to ro.factory.psn and screen density key to ro.sf.lcd_density;
Express to screen density to one decimal places

## Impact

Nop

## Testing

Execute the command `getprop` to get the [key, value] of psn and screen density

